### PR TITLE
Add git alias dsf for diff-so-fancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Edit your `.gitconfig`
   path = ~/dotfiles/gitconfig
 ```
 
+Enable [diff-so-fancy](https://github.com/stevemao/diff-so-fancy) to improve readability.
+
+```
+brew install gnu-sed
+npm install -g diff-so-fancy
+git dsf # dsf is a git-alias for diff-so-fancy
+```
+
 ### Tmux - config
 
 Locate `powerline.conf`

--- a/gitconfig
+++ b/gitconfig
@@ -29,6 +29,7 @@
     hist = log --pretty=format:\"%h %ad | %s%d [%an]\" --graph --date=short
     mylog = log --pretty=format:'%h %s [%an]' --graph
     grp = grep --break --heading --line-number
+    dsf = "!git diff --color $@ | diff-so-fancy"
 [grep]
     extendRegexp = true
     lineNumber = true


### PR DESCRIPTION
Improved diff readability on terminal with diff-so-fancy tool :sparkles: .

![Demo](https://cloud.githubusercontent.com/assets/39191/10000682/8e849130-6052-11e5-9bd9-bd4505cd24d6.png)
